### PR TITLE
Add compatibility with Trey's Sectors Reemergence Patch

### DIFF
--- a/content.xml
+++ b/content.xml
@@ -6,6 +6,7 @@
 	<dependency id="ego_dlc_boron" optional="false" name="Fish People"/>
 	<dependency id="ego_dlc_timelines" optional="true" name="Not Sandbox DLC"/>
 	<dependency version="700"/>
+	<dependency id="addmoresectorsre" optional="true" name="Trey's Sectors Reemergence Patch" comment="let Treys patch god first, then eco patch god, then both will work" />
 	<text language="7" 	name="DeadAir Eco" description="Rebalance of pricing, production, and general economy." author="DeadAir" />
 	<text language="33" name="DeadAir Eco" description="Rebalance of pricing, production, and general economy." author="DeadAir" />
 	<text language="34" name="DeadAir Eco" description="Rebalance of pricing, production, and general economy." author="DeadAir" />


### PR DESCRIPTION
Full context refer to Nexus Mods comment: https://www.nexusmods.com/x4foundations/mods/1556?tab=posts

------

Hi there, it seem [Trey's Sectors] is incompatible with DeadAir_Eco, since both sides are trying to modify the god file:

> [General] 0.00 ======================================
> [=ERROR=] 0.00 No matching node for path '/god/products/product[@ id='tel_dlc_split_weaponcomponents']' in patch file 'extensions\zadd_sectors\libraries\god'. Skipping node.
> [General] 0.00 ======================================

The patches themselves are OK for vanilla, just that if DeadAir_Eco is also used, then the strict matching fails.

A quick fix to this could be telling [Trey's Sectors] to load earlier, or telling DeadAir_Eco to load later. What would be your opinion on this? 

------

With this simple patch on DeadAir_Eco, now Trey's Sectors will load first, which ensures that NPC factories can spawn in Trey's Sectors, and then DeadAir_Eco can modify the details of the NPC factories, eg Teladi Swamp Plant production no longer spawns in Scale Plate Pact sectors.
