### PR TITLE
Exclude DA secondary wares from the new shortage checks

### DIFF
--- a/aiscripts/trade.find.commander.xml
+++ b/aiscripts/trade.find.commander.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='utf-8'?>
+<diff>
+  <add sel="/aiscript/attention/actions/do_if/do_if[@value='not $skipshortage?']/do_if/do_for_each/do_for_each[@in='$table_insufficient']" pos="prepend">
+    <!-- Trading for station, checking insufficient wares -->
+    <do_if value="[ware.da_laborunion_contracts, ware.da_adv_schematics, ware.da_mil_schematics].indexof.{$locware} != 0">
+      <!-- Skip the secondary wares -->
+      <continue />
+    </do_if>
+  </add>
+
+  <add sel="/aiscript/attention/actions/do_if/do_if[@value='not $skipshortage?']/do_if/do_for_each/do_for_each[@in='$table_insufficient']" pos="prepend">
+    <!-- Trading for station, checking shortage wares -->
+    <do_if value="[ware.da_laborunion_contracts, ware.da_adv_schematics, ware.da_mil_schematics].indexof.{$locware} != 0">
+      <!-- Skip the secondary wares -->
+      <continue />
+    </do_if>
+  </add>
+</diff>


### PR DESCRIPTION
This fixes #12.

Because secondary wares are optional, it is not a problem even if they are really in short supply. Therefore, the station trader script is modified to exclude the existing 3 secondary wares (Labor Union Contracts, Advanced Schematics, and Military Schematics) from being ever considered as "in short supply".

This should mean station traders will not easily stop regular trading to look for the (possibly non-existent) secondary wares.

I haven't tested this yet (no available save games for testing), but it "should" work.